### PR TITLE
Add task creation screen and provider updates

### DIFF
--- a/lib/models/task.dart
+++ b/lib/models/task.dart
@@ -1,0 +1,13 @@
+class Task {
+  final String name;
+  final String description;
+  final DateTime deadline;
+  final String status; // urgent, important, simple
+
+  Task({
+    required this.name,
+    required this.description,
+    required this.deadline,
+    required this.status,
+  });
+}

--- a/lib/provider/task_provider.dart
+++ b/lib/provider/task_provider.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/foundation.dart';
+import '../models/task.dart';
 
 class TaskProvider with ChangeNotifier {
-  final List<String> _tasks = [];
+  final List<Task> _tasks = [];
 
-  List<String> get tasks => _tasks;
+  List<Task> get tasks => _tasks;
 
-  void addTask(String task) {
-    if (task.trim().isEmpty) return;
+  void addTask(Task task) {
     _tasks.add(task);
     notifyListeners();
   }

--- a/lib/screens/add_task_screen.dart
+++ b/lib/screens/add_task_screen.dart
@@ -1,0 +1,120 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../models/task.dart';
+import '../provider/task_provider.dart';
+
+class AddTaskScreen extends StatefulWidget {
+  const AddTaskScreen({super.key});
+
+  @override
+  State<AddTaskScreen> createState() => _AddTaskScreenState();
+}
+
+class _AddTaskScreenState extends State<AddTaskScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final TextEditingController _nameController = TextEditingController();
+  final TextEditingController _descriptionController = TextEditingController();
+  DateTime? _deadline;
+  String? _status;
+
+  void _pickDeadline() async {
+    final date = await showDatePicker(
+      context: context,
+      initialDate: DateTime.now(),
+      firstDate: DateTime.now(),
+      lastDate: DateTime(2100),
+    );
+    if (date == null) return;
+    final time = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.now(),
+    );
+    if (time == null) return;
+    setState(() {
+      _deadline = DateTime(
+        date.year,
+        date.month,
+        date.day,
+        time.hour,
+        time.minute,
+      );
+    });
+  }
+
+  void _saveTask() {
+    if (!_formKey.currentState!.validate() || _deadline == null || _status == null) {
+      return;
+    }
+    final task = Task(
+      name: _nameController.text,
+      description: _descriptionController.text,
+      deadline: _deadline!,
+      status: _status!,
+    );
+    Provider.of<TaskProvider>(context, listen: false).addTask(task);
+    Navigator.pop(context);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Add Task')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Form(
+          key: _formKey,
+          child: SingleChildScrollView(
+            child: Column(
+              children: [
+                TextFormField(
+                  controller: _nameController,
+                  decoration: const InputDecoration(labelText: 'Task Name'),
+                  validator: (v) => v == null || v.isEmpty ? 'Enter task name' : null,
+                ),
+                const SizedBox(height: 10),
+                TextFormField(
+                  controller: _descriptionController,
+                  decoration: const InputDecoration(labelText: 'Task Description'),
+                  validator: (v) => v == null || v.isEmpty ? 'Enter description' : null,
+                ),
+                const SizedBox(height: 10),
+                Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        _deadline == null
+                            ? 'No deadline chosen'
+                            : 'Deadline: ${_deadline!.toLocal()}'.split('.').first,
+                      ),
+                    ),
+                    TextButton(
+                      onPressed: _pickDeadline,
+                      child: const Text('Select Deadline'),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 10),
+                DropdownButtonFormField<String>(
+                  decoration: const InputDecoration(labelText: 'Status'),
+                  value: _status,
+                  items: const [
+                    DropdownMenuItem(value: 'urgent', child: Text('Urgent')),
+                    DropdownMenuItem(value: 'important', child: Text('Important')),
+                    DropdownMenuItem(value: 'simple', child: Text('Simple')),
+                  ],
+                  onChanged: (val) => setState(() => _status = val),
+                  validator: (v) => v == null ? 'Select status' : null,
+                ),
+                const SizedBox(height: 20),
+                ElevatedButton(
+                  onPressed: _saveTask,
+                  child: const Text('Save'),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/task_home.dart
+++ b/lib/screens/task_home.dart
@@ -1,66 +1,56 @@
 import 'package:codex/provider/task_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import '../models/task.dart';
+import 'add_task_screen.dart';
 
-class TaskHomePage extends StatefulWidget {
+class TaskHomePage extends StatelessWidget {
   const TaskHomePage({super.key});
-
-  @override
-  State<TaskHomePage> createState() => _TaskHomePageState();
-}
-
-class _TaskHomePageState extends State<TaskHomePage> {
-  final TextEditingController _controller = TextEditingController();
-
-  void _addTask() {
-    Provider.of<TaskProvider>(context, listen: false).addTask(_controller.text);
-    _controller.clear();
-  }
 
   @override
   Widget build(BuildContext context) {
     final tasks = Provider.of<TaskProvider>(context).tasks;
 
     return Scaffold(
-      appBar: AppBar(title: const Text('My Tasks')),
+      appBar: AppBar(
+        title: const Text('My Tasks'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.add),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => const AddTaskScreen()),
+              );
+            },
+          ),
+        ],
+      ),
       body: Padding(
         padding: const EdgeInsets.all(16.0),
-        child: Column(
-          children: [
-            TextField(
-              controller: _controller,
-              decoration: InputDecoration(
-                labelText: 'Enter task',
-                suffixIcon: IconButton(
-                  icon: const Icon(Icons.add),
-                  onPressed: _addTask,
-                ),
-              ),
-              onSubmitted: (_) => _addTask(),
-            ),
-            const SizedBox(height: 20),
-            Expanded(
-              child: tasks.isEmpty
-                  ? const Center(child: Text('No tasks added yet.'))
-                  : ListView.builder(
-                      itemCount: tasks.length,
-                      itemBuilder: (_, index) {
-                        return Dismissible(
-                          key: Key(tasks[index]),
-                          background: Container(color: Colors.red),
-                          onDismissed: (_) {
-                            Provider.of<TaskProvider>(context, listen: false)
-                                .removeTask(index);
-                          },
-                          child: ListTile(
-                            title: Text(tasks[index]),
-                          ),
-                        );
-                      },
+        child: tasks.isEmpty
+            ? const Center(child: Text('No tasks added yet.'))
+            : ListView.builder(
+                itemCount: tasks.length,
+                itemBuilder: (_, index) {
+                  final Task task = tasks[index];
+                  return Dismissible(
+                    key: ValueKey(task.name + task.deadline.toIso8601String()),
+                    background: Container(color: Colors.red),
+                    onDismissed: (_) {
+                      Provider.of<TaskProvider>(context, listen: false)
+                          .removeTask(index);
+                    },
+                    child: ListTile(
+                      title: Text(task.name),
+                      subtitle: Text(
+                        '${task.description}\nDue: ${task.deadline.toLocal().toString().split('.').first}\nStatus: ${task.status}',
+                      ),
+                      isThreeLine: true,
                     ),
-            ),
-          ],
-        ),
+                  );
+                },
+              ),
       ),
     );
   }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,10 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
 import 'package:codex/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
-
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+  testWidgets('App starts and shows home screen', (WidgetTester tester) async {
+    await tester.pumpWidget(const TaskApp());
+    expect(find.text('My Tasks'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- implement a `Task` model to hold task data
- update `TaskProvider` to store `Task` objects
- add `AddTaskScreen` to input task name, description, deadline and status
- modify home screen to display tasks and include a plus icon in the `AppBar` to open the new screen
- update widget test

## Testing
- `flutter analyze` *(fails: `flutter` not installed)*
- `flutter test` *(fails: `flutter` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6853c6b254e4832ba535e4b1fb84c93c